### PR TITLE
retry several times to bring the DUT into bus off mode

### DIFF
--- a/venus-socketcan-test.py
+++ b/venus-socketcan-test.py
@@ -71,14 +71,15 @@ class SocketCanNode:
 		self.eq("should be down", state, "DOWN")
 		print("")
 
-	def if_up(self, bitrate = 250000, restart_ms = 0, tx_queue_len = 10):
+	def if_up(self, bitrate = 250000, restart_ms = 0, tx_queue_len = 10, ignore_upstate = False):
 		print("Up " + str(self))
 		self.run("ip link set " + self._can_if + " txqueuelen " + str(tx_queue_len) +
 				 " up type can bitrate " + str(bitrate) + " restart-ms " + str(restart_ms))
 		self.update_if_details()
 
 		state = self.poll(["linkinfo", "info_data", "state"], "ERROR-ACTIVE")
-		self.eq("up state", state , "ERROR-ACTIVE")
+		if not ignore_upstate:
+			self.eq("up state", state , "ERROR-ACTIVE")
 
 		# wait for link up? USB device postpone that it seems..
 		#state = self.poll(["operstate"], "UP")

--- a/venus-socketcan-test.py
+++ b/venus-socketcan-test.py
@@ -677,9 +677,26 @@ class SocketcanTest:
 		# active error when error-passive. The tester is allowed to
 		# continue sending and can push the dut bus off.
 		self._dut.if_up(bitrate=250000)
-		self._tester.if_up(bitrate=125000)
 
+		self._tester.if_up(bitrate=125000)
 		self._dut.send_stuff_msg()
+		self._tester.if_down()
+
+		self._tester.if_up(bitrate=125000, ignore_upstate=True)
+		self._dut.send_stuff_msg()
+		self._tester.if_down()
+
+		self._tester.if_up(bitrate=125000, ignore_upstate=True)
+		self._dut.send_stuff_msg()
+		self._tester.if_down()
+
+		self._tester.if_up(bitrate=125000, ignore_upstate=True)
+		self._dut.send_stuff_msg()
+		self._tester.if_down()
+
+		self._tester.if_up(bitrate=125000, ignore_upstate=True)
+		self._dut.send_stuff_msg()
+
 		state = self._dut.poll(["linkinfo", "info_data", "state"], "BUS-OFF")
 		self.eq("after pushing bus off", state , "BUS-OFF")
 


### PR DESCRIPTION
On some CAN controllers it takes a bit longer to bring the DUT into bus off mode.